### PR TITLE
add English translation about "How to configure global rate limiting"

### DIFF
--- a/content/en/docs/v1.0/tutorials/global-rate-limit.md
+++ b/content/en/docs/v1.0/tutorials/global-rate-limit.md
@@ -17,24 +17,24 @@ meta-dubbo        Active   16m
 meta-thrift       Active   16m
 ```
 
-## What is global rate limit?
+## What is global rate limiting?
 
-Unlike [local rate limit](/zh/docs/v1.0/tutorials/local-rate-limit/), when using a global rate limit, all service instances share a single limit rate quota. The global rate limit is used to share the limit rate quota between multiple service instances via a rate limiting server.When receiving a request, Sidecar Proxy on the server side will first send a rate limiting query request to rate limiting server, which will read the rules in its own configuration file, then determine whether the request triggers a rate limiting condition according to the rules, finally return result to Sidecar Proxy. Based on the result of this rate limiting, Sidecar Proxy decides whether to disable this request or to continue processing it.
+Unlike [local rate limiting](/zh/docs/v1.0/tutorials/local-rate-limit/), when using a global rate limiting, all service instances share a single rate limiting quota. A global rate limiting server is used to ensure that. When receiving a request, Sidecar Proxy on the server side will first send a rate limiting query request to rate limiting server, which will read the rules in its own configuration file, then determine whether the request triggers a rate limiting condition according to the rules, finally return result to Sidecar Proxy. Based on the result of this rate limiting, Sidecar Proxy decides whether to disable this request or to continue processing it.
 
 ![](../global-rate-limit.png)
 
-## When to use global rate limit?
-The feature of global rate limit is that the limiting judgement is made uniformly at the rate limiting server and is therefore not affected by the number of service instances. However, global rate limit also introduces an additional hop to the rate limiting server, which can introduce additional network latency. In the case of a large number of client requests, the rate limiting server itself is a potential bottleneck point and is more complex to deploy and manage than local limit.
+## When to use global rate limiting?
+The feature of global rate limiting is that the limiting judgement is made uniformly at the rate limiting server and is therefore not affected by the number of service instances. However, global rate limiting also introduces an additional hop to the rate limiting server, which can introduce additional network latency. In the case of a large number of client requests, the rate limiting server itself is a potential bottleneck point and is more complex to deploy and manage than local limiting.
 
-If the purpose of using rate limit is to keep the pressure on the service instance within reasonable limits, it is recommended that local rate limit be used. Because local rate limit is handled separately at each service instance's Sidecar Proxy, local rate limit is more precise and reasonable for controlling inbound requests to service instances in this scenario. With an appropriate HPA policy, it is also possible to horizontally scale the service instances when the existing service instances are fully loaded, ensuring stable service operation.
+If the purpose of using rate limiting is to keep the pressure on the service instance within reasonable limits, it is recommended that local rate limiting be used. Because local rate limiting is handled separately at each service instance's Sidecar Proxy, local rate limiting is more precise and reasonable for controlling inbound requests to service instances in this scenario. With an appropriate HPA policy, it is also possible to horizontally scale the service instances when the existing service instances are fully loaded, ensuring stable service operation.
 
-If the purpose of rate limiting is to enforce a global access policy for access to a particular resource, then full rate limiting should be used. A typical example is to set how often a user can access a service according to user level. Docker Hub, for example, has a different rate limit policy for the number of times a user can pull an image according to user level, with paid users having a higher limit on the number of image pulls than free users.
+If the purpose of rate limiting is to enforce a global access policy for access to a particular resource, then full rate limiting should be used. A typical example is to set how often a user can access a service according to user level. Docker Hub, for example, has a different rate limiting policy for the number of times a user can pull an image according to user level, with paid users having a higher limiting on the number of image pulls than free users.
 
 ## Deploy the rate limiting server
 
 The rate limiting server is already deployed in the example application and the rate limiting rules are configured via the configuration file, so there is no need to deploy it separately.
 
-The rate limiting rules for global rate limit need to be set in the configuration file of the rate limiting server. The following rate limiting rule indicates a rate limiting of 10 streams per minute for the sayHello interface.
+The rate limiting rules for global rate limiting need to be set in the configuration file of the rate limiting server. The following rate limiting rule indicates a rate limiting of 10 streams per minute for the sayHello interface.
 
 ```yaml
 domain: production
@@ -48,15 +48,15 @@ descriptors:
 
 For deployment scripts see:https://github.com/aeraki-mesh/aeraki/tree/master/demo/metaprotocol-thrift/rate-limit-server
 
-> Note: Since the logic of global rate limit is executed in the rate limiting server, the rate limiting rules need to be set in the configuration file of the rate limiting server.
+> Note: Since the logic of global rate limiting is executed in the rate limiting server, the rate limiting rules need to be set in the configuration file of the rate limiting server.
 
-## Enable rate limit for services
+## Enable rate limiting for services
 
-Once rate limit is enabled for the server via MetaRouter, the service's Sidecar Proxy will initiate a rate limit request to the rate limit server upon receipt of the request and will decide whether to continue processing the request or terminate it based on the return of the request.
+Once rate limiting is enabled for the server via MetaRouter, the service's Sidecar Proxy will initiate a rate limiting request to the rate limiting server upon receipt of the request and will decide whether to continue processing the request or terminate it based on the return of the request.
 
-The following global rate limit configuration represents a rate limit to the sayHello interface of the thrift-demo-server.meta-thrift.svc.cluster.local service. The value of the domain in the rate limit request sent to the rate limit server is production and the method attribute is added to the rate limit request as descriptor. Note that the domain and descriptor set here must match the rate limit configuration in the rate limit server.
+The following global rate limiting configuration represents a rate limiting to the sayHello interface of the thrift-demo-server.meta-thrift.svc.cluster.local service. The value of the domain in the rate limiting request sent to the rate limiting server is production and the method attribute is added to the rate limiting request as descriptor. Note that the domain and descriptor set here must match the rate limiting configuration in the rate limiting server.
 
-The match condition can be set in the rate limit settings in MetaRouter.If the match condition is present, only requests that match the condition will be sent to the rate limit server for judgement. If the match condition is not set, then all requests for that service will be sent to the rate limit server for determination. The match condition can be used to filter out requests locally that do not require rate limiting, improving the efficiency of request processing.
+The match condition can be set in the rate limiting settings in MetaRouter.If the match condition is present, only requests that match the condition will be sent to the rate limiting server for judgement. If the match condition is not set, then all requests for that service will be sent to the rate limiting server for determination. The match condition can be used to filter out requests locally that do not require rate limiting, improving the efficiency of request processing.
 ```yaml
 kubectl apply -f- <<EOF
 apiVersion: metaprotocol.aeraki.io/v1alpha1
@@ -101,11 +101,11 @@ org.apache.thrift.TApplicationException: meta protocol local rate limit: request
 ...
 ```
 
-## Understanding the principles of rate limiting
+## Understand what happened
 
 In the configuration issued to the Sidecar Proxy, Aeraki sets up the MetaProtocol Proxy in the FilterChain corresponding to the service in the VirtualInbound Listener.
 
-Aeraki translates MetaRouter to global rate limit filter route configuration, which is distributed to the MetaProtocol Proxy via Aeraki.
+Aeraki translates MetaRouter to global rate limiting filter route configuration, which is distributed to the MetaProtocol Proxy via Aeraki.
 
 The configuration of the sidecar proxy for the service can be viewed with the following command：
 


### PR DESCRIPTION
Signed-off-by: lawrshen <lawrshen@smail.nju.edu.cn>

This PR fix issue #4.

Due to the translation of 'local rate limit' has not been completed, so the reference part is still
```markdown
[local rate limit](/zh/docs/v1.0/tutorials/local-rate-limit/)
```