### PR TITLE
[cleanup] Config: drop dup desc, fix comment indentation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,10 +62,8 @@ markup:
 
 params:
   copyright: Aeraki Mesh Authors
-  description: >-
-    Manage any layer-7 protocols in a service mesh
 
-    # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
+  # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
   github_repo: https://github.com/aeraki-mesh/website
   github_branch: main
 


### PR DESCRIPTION
- Fixes the indentation of the comment `# Repository configuration...` which was wrong, and caused the comment to be part of the `params.description`
- Drops `params.description`. It isn't needed because of the descriptions provided in `languages.{en,zh}.description`
